### PR TITLE
Fix Vale 3.15+ dicpath resolution — drop stray StylesPath from package .vale.ini

### DIFF
--- a/ISC/.vale.ini
+++ b/ISC/.vale.ini
@@ -1,4 +1,3 @@
-StylesPath = styles
 MinAlertLevel = suggestion
 
 Vocab = ISC_General, ISC_Organizations, ISC_People


### PR DESCRIPTION
## Summary

Every repo that consumes this package's `ISC.zip` (`InnerSourcePatterns`, `InnerSourceLearningPath`, `managing-innersource-projects`) has been hitting `vale: unable to resolve dicpath` on every file since Vale 3.15.0 (released 2026-06-12) — unrelated to any PR's content. `InnerSourcePatterns` and `InnerSourceLearningPath` are actively broken today; `managing-innersource-projects` pulls the same unpinned `releases/latest` package and will hit it on its next vale run.

## Root cause

`ISC/.vale.ini`'s `StylesPath = styles` line was written for developing this package standalone and was harmless once distributed — older Vale never read a package's own `.vale.ini` as live config for consumers.

Vale 3.15.0 changed `vale sync` to create/honor the configured `StylesPath` (errata-ai/vale#1106). As a side effect, it now also installs this inner `.vale.ini` as a real sub-config for consumers (`.vale-config/0-ISC.ini`). Sync flattens this package's files into the consumer's `StylesPath`, so `StylesPath = styles` no longer points anywhere real — and it shadows the consumer's actual `StylesPath` when the `Spelling` check resolves `dicpath: dictionaries`, failing on every file in every consuming repo.

## Fix

Drop the stray `StylesPath` line. Verified locally: reproduced the failure with Vale 3.15.1 against `InnerSourcePatterns`, removed this line from the synced sub-config, and vale went from the dicpath crash straight to real spell-check output (flagging real typos like "Ingka", "Moulis", "Contribfest").

## Note on rollout

The `Release` workflow fires automatically on push to `main` under `ISC/**`, so **merging this PR publishes a new release immediately** — every consumer on `releases/latest` (all three above) picks it up on their next `vale sync`. `InnerSourcePatterns` currently has a stopgap version-pin (#916 there) that this fix supersedes; closing that once this is out.
